### PR TITLE
Move json serialize and added type var

### DIFF
--- a/src/logic/chesspieces/chess_piece.php
+++ b/src/logic/chesspieces/chess_piece.php
@@ -2,8 +2,10 @@
 abstract class ChessPiece implements JsonSerializable
 {
     protected String $color;
+    protected String $type;
     protected int $x;
     protected int $y;
+    
     function __construct(String $color, int $x, int $y)
     {
         $this->color = $color;
@@ -37,6 +39,7 @@ abstract class ChessPiece implements JsonSerializable
             'x' => $this->x,
             'y' => $this->y,
             'color' => $this->color,
+            'type' => $this->type,
         ];
     }
 }

--- a/src/logic/chesspieces/chess_piece.php
+++ b/src/logic/chesspieces/chess_piece.php
@@ -1,5 +1,5 @@
 <?php
-abstract class ChessPiece
+abstract class ChessPiece implements JsonSerializable
 {
     protected String $color;
     protected int $x;
@@ -31,4 +31,12 @@ abstract class ChessPiece
     }
 
     abstract function check_move_legal():bool;
+
+    public function jsonSerialize():mixed {
+        return [
+            'x' => $this->x,
+            'y' => $this->y,
+            'color' => $this->color,
+        ];
+    }
 }

--- a/src/logic/chesspieces/pawn.php
+++ b/src/logic/chesspieces/pawn.php
@@ -1,18 +1,11 @@
 <?php
 require_once("chess_piece.php");
 
-class Pawn extends ChessPiece implements JsonSerializable
+class Pawn extends ChessPiece
 {
     function check_move_legal():bool
     {
         return true;
     }
 
-    public function jsonSerialize():mixed {
-        return [
-            'x' => $this->x,
-            'y' => $this->y,
-            'color' => $this->color,
-        ];
-    }
 }

--- a/src/logic/chesspieces/pawn.php
+++ b/src/logic/chesspieces/pawn.php
@@ -2,7 +2,14 @@
 require_once("chess_piece.php");
 
 class Pawn extends ChessPiece
-{
+{   
+
+    function __construct(String $color, int $x, int $y)
+    {
+      parent::__construct($color, $x, $y);
+      $this->type = 'pawn';
+    }
+
     function check_move_legal():bool
     {
         return true;


### PR DESCRIPTION
All pieces will use the serialize method and need to return the var type. ( necessary for the reconstruct board method) 
That's why I moved it from pawn to Chesspieces


closes #5 